### PR TITLE
Add start feature, refactor DataEntryBot and FX400

### DIFF
--- a/Java/FX-400/Automation.java
+++ b/Java/FX-400/Automation.java
@@ -5,8 +5,9 @@ import com.github.kwhat.jnativehook.keyboard.NativeKeyListener;
 
 public class Automation implements NativeKeyListener{
 
+    private final int START_DELAY = 0;
+
     private FX400 fx400;
-    private int START_DELAY;
 
     public static void main(String[] args){
         //Register escape button
@@ -36,6 +37,7 @@ public class Automation implements NativeKeyListener{
         if (e.getKeyCode() == NativeKeyEvent.VC_ALT) {
             try {
                 if(fx400 == null){
+                    Thread.sleep(START_DELAY);
                     fx400 = new FX400();
                     if(!fx400.isAlive()){
                         fx400.start();

--- a/Java/FX-400/Automation.java
+++ b/Java/FX-400/Automation.java
@@ -39,15 +39,16 @@ public class Automation implements NativeKeyListener{
 
         if (e.getKeyCode() == NativeKeyEvent.VC_F2) {
             try {
-                if(fx400 == null){
+                //Start a new thread only if it doesn't exist or is no longer alive
+                if(fx400 == null || (fx400 != null && !fx400.isAlive())){
+                    fx400 = new FX400();
+                }
+
+                if(!fx400.isAlive()){
                     Thread.sleep(START_DELAY);
 
-                    System.out.println("Starting FX400");
-
-                    fx400 = new FX400();
-                    if(!fx400.isAlive()){
-                        fx400.start();
-                    }
+                    System.out.println("Starting FX400 Data Entry");      
+                    fx400.start();
                 }
             } catch (Exception except) {
                 except.printStackTrace();

--- a/Java/FX-400/Automation.java
+++ b/Java/FX-400/Automation.java
@@ -22,11 +22,14 @@ public class Automation implements NativeKeyListener{
 		}
 
         GlobalScreen.addNativeKeyListener(new Automation());
+
+        System.out.println("Program ready. Press ALT to start, ` to Exit.");
     }
 
     public void nativeKeyPressed(NativeKeyEvent e) {
 		if (e.getKeyCode() == NativeKeyEvent.VC_BACKQUOTE) {
             try {
+                System.out.println("Exiting Program");
                 GlobalScreen.unregisterNativeHook();
                 System.exit(0);
             } catch (NativeHookException nativeHookException) {
@@ -38,6 +41,9 @@ public class Automation implements NativeKeyListener{
             try {
                 if(fx400 == null){
                     Thread.sleep(START_DELAY);
+
+                    System.out.println("Starting FX400");
+
                     fx400 = new FX400();
                     if(!fx400.isAlive()){
                         fx400.start();

--- a/Java/FX-400/Automation.java
+++ b/Java/FX-400/Automation.java
@@ -1,0 +1,49 @@
+import com.github.kwhat.jnativehook.GlobalScreen;
+import com.github.kwhat.jnativehook.NativeHookException;
+import com.github.kwhat.jnativehook.keyboard.NativeKeyEvent;
+import com.github.kwhat.jnativehook.keyboard.NativeKeyListener;
+
+public class Automation implements NativeKeyListener{
+
+    private FX400 fx400;
+    private int START_DELAY;
+
+    public static void main(String[] args){
+        //Register escape button
+        try {
+			GlobalScreen.registerNativeHook();
+		}
+		catch (NativeHookException ex) {
+			System.err.println("There was a problem registering the native hook.");
+			System.err.println(ex.getMessage());
+
+			System.exit(1);
+		}
+
+        GlobalScreen.addNativeKeyListener(new Automation());
+    }
+
+    public void nativeKeyPressed(NativeKeyEvent e) {
+		if (e.getKeyCode() == NativeKeyEvent.VC_BACKQUOTE) {
+            try {
+                GlobalScreen.unregisterNativeHook();
+                System.exit(0);
+            } catch (NativeHookException nativeHookException) {
+                nativeHookException.printStackTrace();
+            }
+        }
+
+        if (e.getKeyCode() == NativeKeyEvent.VC_ALT) {
+            try {
+                if(fx400 == null){
+                    fx400 = new FX400();
+                    if(!fx400.isAlive()){
+                        fx400.start();
+                    }
+                }
+            } catch (Exception except) {
+                except.printStackTrace();
+            }
+        }
+	}
+}

--- a/Java/FX-400/Automation.java
+++ b/Java/FX-400/Automation.java
@@ -23,7 +23,7 @@ public class Automation implements NativeKeyListener{
 
         GlobalScreen.addNativeKeyListener(new Automation());
 
-        System.out.println("Program ready. Press ALT to start, ` to Exit.");
+        System.out.println("Program ready. Press F2 to start, ` to Exit.");
     }
 
     public void nativeKeyPressed(NativeKeyEvent e) {
@@ -37,7 +37,7 @@ public class Automation implements NativeKeyListener{
             }
         }
 
-        if (e.getKeyCode() == NativeKeyEvent.VC_ALT) {
+        if (e.getKeyCode() == NativeKeyEvent.VC_F2) {
             try {
                 if(fx400 == null){
                     Thread.sleep(START_DELAY);

--- a/Java/FX-400/Automation.java
+++ b/Java/FX-400/Automation.java
@@ -27,7 +27,10 @@ public class Automation implements NativeKeyListener{
     }
 
     public void nativeKeyPressed(NativeKeyEvent e) {
+        
 		if (e.getKeyCode() == NativeKeyEvent.VC_BACKQUOTE) {
+
+            //Closes the program completely - will have to restart it
             try {
                 System.out.println("Exiting Program");
                 GlobalScreen.unregisterNativeHook();
@@ -35,6 +38,17 @@ public class Automation implements NativeKeyListener{
             } catch (NativeHookException nativeHookException) {
                 nativeHookException.printStackTrace();
             }
+
+            /*
+            //Stops the data entry bot WITHOUT requiring a restart  - this will throw errors, may want to catch them properly
+            try {
+                System.out.println("Exiting Program");
+                fx400.interrupt();
+                fx400.setIsRunning(false);
+            } catch (Exception nativeHookException) {
+                nativeHookException.printStackTrace();
+            }
+            */
         }
 
         if (e.getKeyCode() == NativeKeyEvent.VC_F2) {

--- a/Java/FX-400/DataEntryBot.java
+++ b/Java/FX-400/DataEntryBot.java
@@ -2,13 +2,16 @@ import java.awt.Robot;
 import java.awt.event.KeyEvent;
 
 public class DataEntryBot {
+
+    private final int START_DELAY = 5000; // default 5000
+
     Robot robot;
     int delay = 200;
     private int skipCount = 19;
 
     public DataEntryBot(){
         try {
-            Thread.sleep(5000);
+            Thread.sleep(START_DELAY);
             robot = new Robot();
         } catch (Exception e) {
             System.err.println(e);

--- a/Java/FX-400/DataEntryBot.java
+++ b/Java/FX-400/DataEntryBot.java
@@ -1,239 +1,15 @@
 import java.awt.Robot;
-import java.awt.event.KeyEvent;
 
-public class DataEntryBot {
+public class DataEntryBot extends Robot{
 
-    private final int START_DELAY = 5000; // default 5000
+    private int delay;
 
-    Robot robot;
-    int delay = 200;
-    private int skipCount = 19;
-
-    public DataEntryBot(){
-        try {
-            Thread.sleep(START_DELAY);
-            robot = new Robot();
-        } catch (Exception e) {
-            System.err.println(e);
-        }
+    public DataEntryBot(int delay) throws Exception{
+        this.delay = delay;
     }
 
-    public void skipDevices(){
-        pressKey(KeyEvent.VK_RIGHT, skipCount, 2);
-    }
-    
-
-    public void open(){
-        try {
-            Thread.sleep(delay);
-            robot.keyPress(KeyEvent.VK_SHIFT);
-            robot.keyPress(KeyEvent.VK_F10);
-            robot.keyRelease(KeyEvent.VK_SHIFT);
-            robot.keyRelease(KeyEvent.VK_F10);
-            robot.delay(delay);
-
-            pressKey(KeyEvent.VK_DOWN);
-            pressKey(KeyEvent.VK_ENTER);
-            
-        } catch (Exception e) {
-            System.err.println(e);
-        }
-    }
-    
-
-    public void addPhotoDetector(){
-        open();
-        pressKey(KeyEvent.VK_TAB, 3);
-        skipDevices();
-        pressKey(KeyEvent.VK_ENTER);
-        pressKey(KeyEvent.VK_ESCAPE);
-        pressKey(KeyEvent.VK_END);
-    }
-
-
-    public void addAlarmInputMod(){
-        open();
-        pressKey(KeyEvent.VK_D, 2);
-        pressKey(KeyEvent.VK_TAB, 3);
-        skipDevices();
-        pressKey(KeyEvent.VK_ENTER);
-        pressKey(KeyEvent.VK_ESCAPE);
-        pressKey(KeyEvent.VK_END);
-    }
-
-
-    public void addNonLatchedSupv(){
-        open();
-        pressKey(KeyEvent.VK_D, 2);
-        pressKey(KeyEvent.VK_TAB, 2);
-        pressKey(KeyEvent.VK_N);
-        pressKey(KeyEvent.VK_TAB);
-        skipDevices();
-        pressKey(KeyEvent.VK_ENTER);
-        pressKey(KeyEvent.VK_ESCAPE);
-        pressKey(KeyEvent.VK_END);
-    }
-
-    public void updateSkipCount(int skipCount){
-        this.skipCount = skipCount;
-    }
-
-
-
-    public void addLatchedSupv(){
-        open();
-        pressKey(KeyEvent.VK_D,2);
-        pressKey(KeyEvent.VK_TAB,2);
-        pressKey(KeyEvent.VK_L);
-        pressKey(KeyEvent.VK_TAB);
-        skipDevices();
-        pressKey(KeyEvent.VK_ENTER);
-        pressKey(KeyEvent.VK_ESCAPE);
-        pressKey(KeyEvent.VK_END);
-    }
-
-    public void addHeatDetector(){
-        open();
-        pressKey(KeyEvent.VK_H,3);
-        pressKey(KeyEvent.VK_TAB,3);
-        skipDevices();
-        pressKey(KeyEvent.VK_ENTER);
-        pressKey(KeyEvent.VK_ESCAPE);
-        pressKey(KeyEvent.VK_END);
-    }
-
-    public void addAlarmInputClassA(){
-        open();
-        pressKey(KeyEvent.VK_D, 2);
-        pressKey(KeyEvent.VK_TAB, 1);
-        pressKey(KeyEvent.VK_C, 1);
-        pressKey(KeyEvent.VK_TAB, 2);
-        skipDevices();
-        pressKey(KeyEvent.VK_ENTER);
-        pressKey(KeyEvent.VK_ESCAPE);
-        pressKey(KeyEvent.VK_END);
-    }
-
-
-
-    public void addRelay(){
-        open();
-        pressKey(KeyEvent.VK_D);
-        pressKey(KeyEvent.VK_TAB, 2);
-        skipDevices();
-        pressKey(KeyEvent.VK_ENTER);
-        pressKey(KeyEvent.VK_ESCAPE);
-        pressKey(KeyEvent.VK_END);
-    }
-
-    private void enterTag(String tag){
-        try {
-            Thread.sleep(delay);
-            for(int i = 0; i < tag.length(); i++){
-                char c = tag.charAt(i);
-                int keyCode = KeyEvent.getExtendedKeyCodeForChar(c);
-                if (keyCode == KeyEvent.VK_UNDEFINED) {
-                    System.err.println("Key code not found for character: " + c);
-                } else {
-                    robot.keyPress(keyCode); robot.keyRelease(keyCode); Thread.sleep(15);
-                }
-            }
-        } catch (Exception e) {
-            System.err.println(e);
-        }
-    }
-
-    private void updateTags(Zone zone){
-        try {
-            Thread.sleep(delay);
-            robot.keyPress(KeyEvent.VK_ENTER); robot.keyRelease(KeyEvent.VK_ENTER); robot.delay(delay);
-            enterTag(zone.getTag1());
-            robot.keyPress(KeyEvent.VK_ENTER); robot.keyRelease(KeyEvent.VK_ENTER); robot.delay(delay);
-            enterTag(zone.getTag2());
-            robot.keyPress(KeyEvent.VK_ENTER); robot.keyRelease(KeyEvent.VK_ENTER); robot.delay(delay);
-        } catch (Exception e) {
-            // TODO: handle exception
-        }
-    }
-
-    private void updateType(Zone zone){
-        try {
-            Thread.sleep(delay);
-            switch(zone.getType()){
-                case "Photo Detector":
-                    pressKey(KeyEvent.VK_A);
-                    break;
-                case "Alarm Input":
-                    pressKey(KeyEvent.VK_M);
-                    pressKey(KeyEvent.VK_A, 3);
-                    break;
-                case "Non-latched Supervisory":
-                    pressKey(KeyEvent.VK_N);
-                    break;
-                case "Latched Supervisory":
-                    pressKey(KeyEvent.VK_L);
-                    break;
-                case "Heat Detector":
-                    pressKey(KeyEvent.VK_M);
-                    pressKey(KeyEvent.VK_A, 3);
-                    break;
-                case "Blank Device":
-                    pressKey(KeyEvent.VK_N);
-                    pressKey(KeyEvent.VK_B, 2);
-                    break;
-                case "Relay":
-                    pressKey(KeyEvent.VK_R);
-                    break;
-            }
-            robot.keyPress(KeyEvent.VK_ENTER); robot.keyRelease(KeyEvent.VK_ENTER); robot.delay(delay);
-        } catch (Exception e) {
-            // TODO: handle exception
-        }
-    }
-
-    private void updateRow(Zone zone){
-        updateTags(zone);
-        updateType(zone);
-        
-        if(zone.isNS()){
-            pressKey(KeyEvent.VK_N);
-        }
-
-        pressKey(KeyEvent.VK_ENTER);
-        pressKey(KeyEvent.VK_ESCAPE);
-        pressKey(KeyEvent.VK_DOWN);
-    }
-
-
-    private void updateZone(Zone zone){
-        try {
-            updateRow(zone);
-
-            if (zone.getSubAddress() != null){
-                updateRow(zone.getSubAddress());
-            } else if(zone.isDualInput() || zone.getType().equals("Relay")) {
-                // add empty
-                updateRow(new subZone(zone.getAddress()+0.1, "    Spare", zone.getTag2()));
-            }
-        } catch (Exception e) {
-            // TODO: handle exception
-            System.out.println(e);
-        }
-        
-    }
-
-    public void enterZoneList(ZoneList zoneList){
-        try {
-            pressKey(KeyEvent.VK_HOME); 
-            for(Zone zone : zoneList.zones){
-                if(!zone.getType().equals("Blank Device")){
-                    updateZone(zone);
-                }
-            }
-            
-        } catch (Exception e) {
-            // TODO: handle exception
-        }
+    public DataEntryBot() throws Exception{
+        this(200);
     }
 
     //Give key and distance, press and release key distance times, and delay if provided
@@ -244,10 +20,10 @@ public class DataEntryBot {
 
             for(int i = 0; i < targetDistance; i++){
             
-                robot.keyPress(key); 
-                robot.keyRelease(key);
+                this.keyPress(key); 
+                this.keyRelease(key);
 
-                robot.delay(delay);
+                this.delay(delay);
 
                 if (threadSleep > 0)
                 {

--- a/Java/FX-400/DataEntryBot.java
+++ b/Java/FX-400/DataEntryBot.java
@@ -30,7 +30,7 @@ public class DataEntryBot extends Robot{
                 }
             }
         }catch (Exception e) {
-            // TODO: handle exception
+            e.printStackTrace();
         }
     }  
 

--- a/Java/FX-400/DataEntryBot.java
+++ b/Java/FX-400/DataEntryBot.java
@@ -19,15 +19,14 @@ public class DataEntryBot extends Robot{
             Thread.sleep(delay);
 
             for(int i = 0; i < targetDistance; i++){
-            
+
                 this.keyPress(key); 
                 this.keyRelease(key);
 
                 this.delay(delay);
 
-                if (threadSleep > 0)
-                {
-                    Thread.sleep(15);
+                if (threadSleep > 0){
+                    Thread.sleep(threadSleep);
                 }
             }
         }catch (Exception e) {
@@ -35,13 +34,11 @@ public class DataEntryBot extends Robot{
         }
     }  
 
-    public void pressKey(int key, int targetDistance)
-    {
+    public void pressKey(int key, int targetDistance){
         pressKey(key, targetDistance, 0);
     }
 
-    public void pressKey(int key)
-    {
+    public void pressKey(int key){
         pressKey(key, 1, 0);
     }
 }

--- a/Java/FX-400/FX400.java
+++ b/Java/FX-400/FX400.java
@@ -1,124 +1,316 @@
 import java.util.ArrayList;
-import com.github.kwhat.jnativehook.GlobalScreen;
-import com.github.kwhat.jnativehook.NativeHookException;
-import com.github.kwhat.jnativehook.keyboard.NativeKeyEvent;
-import com.github.kwhat.jnativehook.keyboard.NativeKeyListener;
+import java.awt.event.KeyEvent;
 
-public class FX400 implements NativeKeyListener{
+public class FX400 extends Thread{
 
-    public static void main(String[] args) throws Exception {
+    private DataEntryBot bot;
+    private int skip_count = 19;
+    private int delay = 200;
 
-        //Register escape button
+    public FX400(){
         try {
-			GlobalScreen.registerNativeHook();
-		}
-		catch (NativeHookException ex) {
-			System.err.println("There was a problem registering the native hook.");
-			System.err.println(ex.getMessage());
-
-			System.exit(1);
-		}
-
-		GlobalScreen.addNativeKeyListener(new FX400());
-
-        //Data entry stuff
-        DataEntryBot bot = new DataEntryBot();
-        ReadTempArray reader = new ReadTempArray();
-        String[][] zoneParts = reader.readFile();
-        ZoneList zoneList = new ZoneList();
-
-        String[] addresses = zoneParts[0];
-        String[] tags1 = zoneParts[1];
-        String[] tags2 = zoneParts[2];
-
-        for (int i = 0; i < addresses.length; i++) {
-            System.out.println(" - - - - -  + " + tags1[i]);
-            zoneList.addZone(Double.parseDouble(addresses[i]), tags1[i], tags2[i]);
+            //Thread.sleep(START_DELAY);
+            bot = new DataEntryBot();
+        } catch (Exception e) {
+            System.err.println(e);
         }
-
-        zoneList.displayZoneList();
-
-        ArrayList<Zone> zones = zoneList.zones;
-        Zone zone = zones.get(0);
-        int skip_count = (int) zone.getAddress() - 1;
-
-        for(int current_zone = 0; current_zone < zones.size(); current_zone++) {
-
-            zone = zones.get(current_zone);
-            //Get difference of current and previous address, then -1
-            if(current_zone > 0){
-                skip_count += (int) zone.getAddress() - (int) zones.get(current_zone - 1).getAddress() - 1;
-            }
-
-            System.out.println("Checking: " + zone.getZoneinfo());
-
-            bot.updateSkipCount(skip_count);
-
-            switch (zone.getType()) {
-                case "Photo Detector":
-                    bot.addPhotoDetector();
-                    break;
-                case "Alarm Input":
-                    bot.addAlarmInputMod();
-                    break;
-                case "Non-latched Supervisory":
-                    bot.addNonLatchedSupv();
-                    break;
-                case "Latched Supervisory":
-                    bot.addLatchedSupv();
-                    break;
-                case "Heat Detector":
-                    bot.addHeatDetector();
-                    break;
-                case "Alarm Input Class A":
-                    bot.addAlarmInputClassA();
-                    break;
-                case "Relay":
-                    bot.addRelay();
-                    break;
-            }
-        }
-
-       bot.enterZoneList(zoneList);
-
-        // zoneList.addZone(1.1, "Waterflow ");
-        // zoneList.addZone(2.1, "valve ");
-        // zoneList.addZone(2.2, "discharge ");
-        // zoneList.addZone(3.1, "Damper ");
-        // zoneList.addZone(4.1, "jocky ");
-        // zoneList.addZone(5.1, "duct ");
-        // zoneList.addZone(5.2, "bypass ");
-        // zoneList.addZone(20, "waterflow");
-        // zoneList.addZone(21, "smoke");
-
-        // if (Zone.classify("smoke").equals("Photo Detector")) {
-        // bot.addPhotoDetector();
-        // }
-
-        // System.out.println(Zone.classify("Waterflow "));
-        // System.out.println(Zone.classify("valve "));
-        // System.out.println(Zone.classify("smoke "));
-        // System.out.println(Zone.classify("Damper "));
-        // System.out.println(Zone.classify("jocky "));
-        // System.out.println(Zone.classify("duct "));
-        // System.out.println(Zone.classify("bypass "));
-
-        // //Simulate typing "Hello, World!"
-        // robot.keyPress(KeyEvent.VK_H);
-        // robot.keyRelease(KeyEvent.VK_H);
-        // robot.keyPress(KeyEvent.VK_E);
-        // robot.keyRelease(KeyEvent.VK_E);
-        // // ... (and so on)
     }
 
-    public void nativeKeyPressed(NativeKeyEvent e) {
-		if (e.getKeyCode() == NativeKeyEvent.VC_BACKQUOTE) {
-            try {
-                GlobalScreen.unregisterNativeHook();
-                System.exit(0);
-            } catch (NativeHookException nativeHookException) {
-                nativeHookException.printStackTrace();
+    public void run() {
+        try{
+            ReadTempArray reader = new ReadTempArray();
+            String[][] zoneParts = reader.readFile();
+            ZoneList zoneList = new ZoneList();
+
+            String[] addresses = zoneParts[0];
+            String[] tags1 = zoneParts[1];
+            String[] tags2 = zoneParts[2];
+
+            for (int i = 0; i < addresses.length; i++) {
+                System.out.println(" - - - - -  + " + tags1[i]);
+                zoneList.addZone(Double.parseDouble(addresses[i]), tags1[i], tags2[i]);
             }
+
+            zoneList.displayZoneList();
+
+            ArrayList<Zone> zones = zoneList.zones;
+            Zone zone = zones.get(0);
+            skip_count = (int) zone.getAddress() - 1;
+
+            for(int current_zone = 0; current_zone < zones.size(); current_zone++) {
+
+                zone = zones.get(current_zone);
+                //Get difference of current and previous address, then -1
+                if(current_zone > 0){
+                    skip_count += (int) zone.getAddress() - (int) zones.get(current_zone - 1).getAddress() - 1;
+                }
+
+                System.out.println("Checking: " + zone.getZoneinfo());
+
+                switch (zone.getType()) {
+                    case "Photo Detector":
+                        addPhotoDetector();
+                        break;
+                    case "Alarm Input":
+                        addAlarmInputMod();
+                        break;
+                    case "Non-latched Supervisory":
+                        addNonLatchedSupv();
+                        break;
+                    case "Latched Supervisory":
+                        addLatchedSupv();
+                        break;
+                    case "Heat Detector":
+                        addHeatDetector();
+                        break;
+                    case "Alarm Input Class A":
+                        addAlarmInputClassA();
+                        break;
+                    case "Relay":
+                        addRelay();
+                        break;
+                }
+            }
+
+        enterZoneList(zoneList);
+
+            // zoneList.addZone(1.1, "Waterflow ");
+            // zoneList.addZone(2.1, "valve ");
+            // zoneList.addZone(2.2, "discharge ");
+            // zoneList.addZone(3.1, "Damper ");
+            // zoneList.addZone(4.1, "jocky ");
+            // zoneList.addZone(5.1, "duct ");
+            // zoneList.addZone(5.2, "bypass ");
+            // zoneList.addZone(20, "waterflow");
+            // zoneList.addZone(21, "smoke");
+
+            // if (Zone.classify("smoke").equals("Photo Detector")) {
+            // bot.addPhotoDetector();
+            // }
+
+            // System.out.println(Zone.classify("Waterflow "));
+            // System.out.println(Zone.classify("valve "));
+            // System.out.println(Zone.classify("smoke "));
+            // System.out.println(Zone.classify("Damper "));
+            // System.out.println(Zone.classify("jocky "));
+            // System.out.println(Zone.classify("duct "));
+            // System.out.println(Zone.classify("bypass "));
+
+            // //Simulate typing "Hello, World!"
+            // bot.keyPress(KeyEvent.VK_H);
+            // bot.keyRelease(KeyEvent.VK_H);
+            // bot.keyPress(KeyEvent.VK_E);
+            // bot.keyRelease(KeyEvent.VK_E);
+            // // ... (and so on)
         }
-	}
+        catch(Exception e){
+
+        }
+    }
+
+    public void skipDevices(){
+        bot.pressKey(KeyEvent.VK_RIGHT, skip_count, 2);
+    }
+
+    public void open(){
+        try {
+            Thread.sleep(delay);
+            bot.keyPress(KeyEvent.VK_SHIFT);
+            bot.keyPress(KeyEvent.VK_F10);
+            bot.keyRelease(KeyEvent.VK_SHIFT);
+            bot.keyRelease(KeyEvent.VK_F10);
+            bot.delay(delay);
+
+            bot.pressKey(KeyEvent.VK_DOWN);
+            bot.pressKey(KeyEvent.VK_ENTER);
+            
+        } catch (Exception e) {
+            System.err.println(e);
+        }
+    }
+    
+    public void addPhotoDetector(){
+        open();
+        bot.pressKey(KeyEvent.VK_TAB, 3);
+        skipDevices();
+        bot.pressKey(KeyEvent.VK_ENTER);
+        bot.pressKey(KeyEvent.VK_ESCAPE);
+        bot.pressKey(KeyEvent.VK_END);
+    }
+
+    public void addAlarmInputMod(){
+        open();
+        bot.pressKey(KeyEvent.VK_D, 2);
+        bot.pressKey(KeyEvent.VK_TAB, 3);
+        skipDevices();
+        bot.pressKey(KeyEvent.VK_ENTER);
+        bot.pressKey(KeyEvent.VK_ESCAPE);
+        bot.pressKey(KeyEvent.VK_END);
+    }
+
+    public void addNonLatchedSupv(){
+        open();
+        bot.pressKey(KeyEvent.VK_D, 2);
+        bot.pressKey(KeyEvent.VK_TAB, 2);
+        bot.pressKey(KeyEvent.VK_N);
+        bot.pressKey(KeyEvent.VK_TAB);
+        skipDevices();
+        bot.pressKey(KeyEvent.VK_ENTER);
+        bot.pressKey(KeyEvent.VK_ESCAPE);
+        bot.pressKey(KeyEvent.VK_END);
+    }
+
+    public void addLatchedSupv(){
+        open();
+        bot.pressKey(KeyEvent.VK_D,2);
+        bot.pressKey(KeyEvent.VK_TAB,2);
+        bot.pressKey(KeyEvent.VK_L);
+        bot.pressKey(KeyEvent.VK_TAB);
+        skipDevices();
+        bot.pressKey(KeyEvent.VK_ENTER);
+        bot.pressKey(KeyEvent.VK_ESCAPE);
+        bot.pressKey(KeyEvent.VK_END);
+    }
+
+    public void addHeatDetector(){
+        open();
+        bot.pressKey(KeyEvent.VK_H,3);
+        bot.pressKey(KeyEvent.VK_TAB,3);
+        skipDevices();
+        bot.pressKey(KeyEvent.VK_ENTER);
+        bot.pressKey(KeyEvent.VK_ESCAPE);
+        bot.pressKey(KeyEvent.VK_END);
+    }
+
+    public void addAlarmInputClassA(){
+        open();
+        bot.pressKey(KeyEvent.VK_D, 2);
+        bot.pressKey(KeyEvent.VK_TAB, 1);
+        bot.pressKey(KeyEvent.VK_C, 1);
+        bot.pressKey(KeyEvent.VK_TAB, 2);
+        skipDevices();
+        bot.pressKey(KeyEvent.VK_ENTER);
+        bot.pressKey(KeyEvent.VK_ESCAPE);
+        bot.pressKey(KeyEvent.VK_END);
+    }
+
+    public void addRelay(){
+        open();
+        bot.pressKey(KeyEvent.VK_D);
+        bot.pressKey(KeyEvent.VK_TAB, 2);
+        skipDevices();
+        bot.pressKey(KeyEvent.VK_ENTER);
+        bot.pressKey(KeyEvent.VK_ESCAPE);
+        bot.pressKey(KeyEvent.VK_END);
+    }
+
+    private void enterTag(String tag){
+        try {
+            Thread.sleep(delay);
+            for(int i = 0; i < tag.length(); i++){
+                char c = tag.charAt(i);
+                int keyCode = KeyEvent.getExtendedKeyCodeForChar(c);
+                if (keyCode == KeyEvent.VK_UNDEFINED) {
+                    System.err.println("Key code not found for character: " + c);
+                } else {
+                    bot.keyPress(keyCode); bot.keyRelease(keyCode); Thread.sleep(15);
+                }
+            }
+        } catch (Exception e) {
+            System.err.println(e);
+        }
+    }
+
+    private void updateTags(Zone zone){
+        try {
+            Thread.sleep(delay);
+            bot.keyPress(KeyEvent.VK_ENTER); bot.keyRelease(KeyEvent.VK_ENTER); bot.delay(delay);
+            enterTag(zone.getTag1());
+            bot.keyPress(KeyEvent.VK_ENTER); bot.keyRelease(KeyEvent.VK_ENTER); bot.delay(delay);
+            enterTag(zone.getTag2());
+            bot.keyPress(KeyEvent.VK_ENTER); bot.keyRelease(KeyEvent.VK_ENTER); bot.delay(delay);
+        } catch (Exception e) {
+            // TODO: handle exception
+        }
+    }
+
+    private void updateType(Zone zone){
+        try {
+            Thread.sleep(delay);
+            switch(zone.getType()){
+                case "Photo Detector":
+                    bot.pressKey(KeyEvent.VK_A);
+                    break;
+                case "Alarm Input":
+                    bot.pressKey(KeyEvent.VK_M);
+                    bot.pressKey(KeyEvent.VK_A, 3);
+                    break;
+                case "Non-latched Supervisory":
+                    bot.pressKey(KeyEvent.VK_N);
+                    break;
+                case "Latched Supervisory":
+                    bot.pressKey(KeyEvent.VK_L);
+                    break;
+                case "Heat Detector":
+                    bot.pressKey(KeyEvent.VK_M);
+                    bot.pressKey(KeyEvent.VK_A, 3);
+                    break;
+                case "Blank Device":
+                    bot.pressKey(KeyEvent.VK_N);
+                    bot.pressKey(KeyEvent.VK_B, 2);
+                    break;
+                case "Relay":
+                    bot.pressKey(KeyEvent.VK_R);
+                    break;
+            }
+            bot.keyPress(KeyEvent.VK_ENTER); bot.keyRelease(KeyEvent.VK_ENTER); bot.delay(delay);
+        } catch (Exception e) {
+            // TODO: handle exception
+        }
+    }
+
+    private void updateRow(Zone zone){
+        updateTags(zone);
+        updateType(zone);
+        
+        if(zone.isNS()){
+            bot.pressKey(KeyEvent.VK_N);
+        }
+
+        bot.pressKey(KeyEvent.VK_ENTER);
+        bot.pressKey(KeyEvent.VK_ESCAPE);
+        bot.pressKey(KeyEvent.VK_DOWN);
+    }
+
+
+    private void updateZone(Zone zone){
+        try {
+            updateRow(zone);
+
+            if (zone.getSubAddress() != null){
+                updateRow(zone.getSubAddress());
+            } else if(zone.isDualInput() || zone.getType().equals("Relay")) {
+                // add empty
+                updateRow(new subZone(zone.getAddress()+0.1, "    Spare", zone.getTag2()));
+            }
+        } catch (Exception e) {
+            // TODO: handle exception
+            System.out.println(e);
+        }
+        
+    }
+
+    public void enterZoneList(ZoneList zoneList){
+        try {
+            bot.pressKey(KeyEvent.VK_HOME); 
+            for(Zone zone : zoneList.zones){
+                if(!zone.getType().equals("Blank Device")){
+                    updateZone(zone);
+                }
+            }
+            
+        } catch (Exception e) {
+            // TODO: handle exception
+        }
+    }
 }

--- a/Java/FX-400/FX400.java
+++ b/Java/FX-400/FX400.java
@@ -11,7 +11,7 @@ public class FX400 extends Thread{
         try {
             bot = new DataEntryBot();
         } catch (Exception e) {
-            System.err.println(e);
+            e.printStackTrace();
         }
     }
 
@@ -104,6 +104,7 @@ public class FX400 extends Thread{
             System.out.println("FX400 Entry Complete");
         }
         catch(Exception e){
+            e.printStackTrace();
         }
     }
 
@@ -232,7 +233,7 @@ public class FX400 extends Thread{
             //bot.keyPress(KeyEvent.VK_ENTER); bot.keyRelease(KeyEvent.VK_ENTER); bot.delay(delay);
             bot.pressKey(KeyEvent.VK_ENTER, 1, 15);
         } catch (Exception e) {
-            // TODO: handle exception
+            e.printStackTrace();
         }
     }
 
@@ -267,7 +268,7 @@ public class FX400 extends Thread{
             }
             bot.keyPress(KeyEvent.VK_ENTER); bot.keyRelease(KeyEvent.VK_ENTER); bot.delay(delay);
         } catch (Exception e) {
-            // TODO: handle exception
+            e.printStackTrace();
         }
     }
 
@@ -296,8 +297,7 @@ public class FX400 extends Thread{
                 updateRow(new subZone(zone.getAddress()+0.1, "    Spare", zone.getTag2()));
             }
         } catch (Exception e) {
-            // TODO: handle exception
-            System.out.println(e);
+            e.printStackTrace();
         }
         
     }
@@ -312,7 +312,7 @@ public class FX400 extends Thread{
             }
             
         } catch (Exception e) {
-            // TODO: handle exception
+            e.printStackTrace();
         }
     }
 }

--- a/Java/FX-400/FX400.java
+++ b/Java/FX-400/FX400.java
@@ -6,6 +6,7 @@ public class FX400 extends Thread{
     private DataEntryBot bot;
     private int skip_count = 19;
     private int delay = 200;
+    private boolean is_running = false; //used to stop the bot from running without closing process
 
     public FX400(){
         try {
@@ -17,6 +18,8 @@ public class FX400 extends Thread{
 
     public void run() {
         try{
+            is_running = true;
+
             ReadTempArray reader = new ReadTempArray();
             String[][] zoneParts = reader.readFile();
             ZoneList zoneList = new ZoneList();
@@ -36,7 +39,7 @@ public class FX400 extends Thread{
             Zone zone = zones.get(0);
             skip_count = (int) zone.getAddress() - 1;
 
-            for(int current_zone = 0; current_zone < zones.size(); current_zone++) {
+            for(int current_zone = 0; current_zone < zones.size() && is_running; current_zone++) {
 
                 zone = zones.get(current_zone);
                 //Get difference of current and previous address, then -1
@@ -71,8 +74,9 @@ public class FX400 extends Thread{
                 }
             }
 
-            enterZoneList(zoneList);
-
+            if(is_running){
+                enterZoneList(zoneList);
+            }
             // zoneList.addZone(1.1, "Waterflow ");
             // zoneList.addZone(2.1, "valve ");
             // zoneList.addZone(2.2, "discharge ");
@@ -102,6 +106,7 @@ public class FX400 extends Thread{
             // bot.keyRelease(KeyEvent.VK_E);
             // // ... (and so on)
             System.out.println("FX400 Entry Complete");
+            is_running = false;
         }
         catch(Exception e){
             e.printStackTrace();
@@ -310,6 +315,15 @@ public class FX400 extends Thread{
             
         } catch (Exception e) {
             e.printStackTrace();
+        }
+    }
+
+    public void setIsRunning(boolean status){
+        is_running = status;
+
+        //Set bot to null to prevent further inputs
+        if(!is_running){
+            bot = null;
         }
     }
 }

--- a/Java/FX-400/FX400.java
+++ b/Java/FX-400/FX400.java
@@ -224,13 +224,10 @@ public class FX400 extends Thread{
     private void updateTags(Zone zone){
         try {
             Thread.sleep(delay);
-            //bot.keyPress(KeyEvent.VK_ENTER); bot.keyRelease(KeyEvent.VK_ENTER); bot.delay(delay);
             bot.pressKey(KeyEvent.VK_ENTER, 1, 15);
             enterTag(zone.getTag1());
-            //bot.keyPress(KeyEvent.VK_ENTER); bot.keyRelease(KeyEvent.VK_ENTER); bot.delay(delay);
             bot.pressKey(KeyEvent.VK_ENTER, 1, 15);
             enterTag(zone.getTag2());
-            //bot.keyPress(KeyEvent.VK_ENTER); bot.keyRelease(KeyEvent.VK_ENTER); bot.delay(delay);
             bot.pressKey(KeyEvent.VK_ENTER, 1, 15);
         } catch (Exception e) {
             e.printStackTrace();

--- a/Java/FX-400/FX400.java
+++ b/Java/FX-400/FX400.java
@@ -9,7 +9,6 @@ public class FX400 extends Thread{
 
     public FX400(){
         try {
-            //Thread.sleep(START_DELAY);
             bot = new DataEntryBot();
         } catch (Exception e) {
             System.err.println(e);
@@ -72,7 +71,7 @@ public class FX400 extends Thread{
                 }
             }
 
-        enterZoneList(zoneList);
+            enterZoneList(zoneList);
 
             // zoneList.addZone(1.1, "Waterflow ");
             // zoneList.addZone(2.1, "valve ");
@@ -102,9 +101,9 @@ public class FX400 extends Thread{
             // bot.keyPress(KeyEvent.VK_E);
             // bot.keyRelease(KeyEvent.VK_E);
             // // ... (and so on)
+            System.out.println("FX400 Entry Complete");
         }
         catch(Exception e){
-
         }
     }
 
@@ -224,11 +223,14 @@ public class FX400 extends Thread{
     private void updateTags(Zone zone){
         try {
             Thread.sleep(delay);
-            bot.keyPress(KeyEvent.VK_ENTER); bot.keyRelease(KeyEvent.VK_ENTER); bot.delay(delay);
+            //bot.keyPress(KeyEvent.VK_ENTER); bot.keyRelease(KeyEvent.VK_ENTER); bot.delay(delay);
+            bot.pressKey(KeyEvent.VK_ENTER, 1, 15);
             enterTag(zone.getTag1());
-            bot.keyPress(KeyEvent.VK_ENTER); bot.keyRelease(KeyEvent.VK_ENTER); bot.delay(delay);
+            //bot.keyPress(KeyEvent.VK_ENTER); bot.keyRelease(KeyEvent.VK_ENTER); bot.delay(delay);
+            bot.pressKey(KeyEvent.VK_ENTER, 1, 15);
             enterTag(zone.getTag2());
-            bot.keyPress(KeyEvent.VK_ENTER); bot.keyRelease(KeyEvent.VK_ENTER); bot.delay(delay);
+            //bot.keyPress(KeyEvent.VK_ENTER); bot.keyRelease(KeyEvent.VK_ENTER); bot.delay(delay);
+            bot.pressKey(KeyEvent.VK_ENTER, 1, 15);
         } catch (Exception e) {
             // TODO: handle exception
         }

--- a/Java/FX-400/start.bat
+++ b/Java/FX-400/start.bat
@@ -1,3 +1,3 @@
 python ./tools/excelReader.py
-javac -cp  dependencies/* FX400.java ZoneList.java Zone.java ReadTempArray.java DataEntryBot.java
-java -cp  dependencies/* FX400.java
+javac -cp  dependencies/* Automation.java FX400.java ZoneList.java Zone.java ReadTempArray.java DataEntryBot.java
+java -cp  dependencies/* Automation.java

--- a/Java/FX-400/start.bat
+++ b/Java/FX-400/start.bat
@@ -1,3 +1,4 @@
 python ./tools/excelReader.py
 javac -cp  dependencies/* Automation.java FX400.java ZoneList.java Zone.java ReadTempArray.java DataEntryBot.java
-java -cp  dependencies/* Automation.java
+java --enable-native-access=ALL-UNNAMED -cp dependencies/* Automation.java
+


### PR DESCRIPTION
- Automation.java is now the new main

  -  panel is meant to be decided here
  -  runs the panel bot on a new thread, so the hook listener won't be backed up
  -  no longer need to restart the program to run data entry again
  - there is a commented out portion that can be used to stop the program without closing it entirely, this will likely be useful with a gui

- DataEntryBot now extends Robot, it's meant for other panels to be able to use it as well
- DataEntryBot code moved to FX400 since it's exclusive to that panel
